### PR TITLE
Get name from entity instead of form data

### DIFF
--- a/sepapp.php
+++ b/sepapp.php
@@ -249,7 +249,7 @@ function sepapp_civicrm_postProcess($formName, &$form)
                     $paymentProcessor = civicrm_api3(
                         'PaymentProcessor',
                         'getsingle',
-                        array('name' => $form->_submitValues['name'], 'is_test' => 0)
+                        array('name' => $pp['name'], 'is_test' => 0)
                     );
 
                     $creditor_id      = $form->_submitValues['user_name'];


### PR DESCRIPTION
This fixes the exception described in #19, introduced in CiviCRM 5.61
