### PR TITLE
NG Processor: Throws error for event payment #17

### DIFF
--- a/CRM/Core/Payment/SDDNG.php
+++ b/CRM/Core/Payment/SDDNG.php
@@ -220,6 +220,11 @@ class CRM_Core_Payment_SDDNG extends CRM_Core_Payment
         return null;
     }
 
+    public static function setPendingContributionID(int $contribution_id) {
+        self::$_pending_mandate['contribution_id'] = $contribution_id;
+        self::$_pending_mandate['contributionID'] = $contribution_id;
+    }
+
     public static function releasePendingMandateData($contribution_id)
     {
         if (!self::$_pending_mandate) {

--- a/sepapp.php
+++ b/sepapp.php
@@ -265,13 +265,23 @@ function sepapp_civicrm_postProcess($formName, &$form)
                 throw new Exception("Couldn't find PaymentProcessorType [{$pp_id}]");
             }
         }
-    } elseif ('CRM_Contribute_Form_Contribution_Confirm' == $formName) {
-        // post process the contributions created
-        CRM_Core_Payment_SDD::processPartialMandates();
-    } elseif ('CRM_Event_Form_Registration_Confirm' == $formName) {
+    } elseif ('CRM_Contribute_Form_Contribution_Confirm' == $formName || 'CRM_Event_Form_Registration_Confirm' == $formName) {
+        // SDD: make sure mandate is created:
+        CRM_Core_Payment_SDDNGPostProcessor::createPendingMandate();
+
         // post process the contributions created
         CRM_Core_Payment_SDD::processPartialMandates();
     }
+}
+
+/**
+ * Implements hook_civicrm_postSave_[table_name].
+ *
+ * We have to use this because comletetransaction apiWrapper does not work.
+ */
+function sepapp_civicrm_postSave_civicrm_contribution($dao) {
+    $contribution_id = $dao->id;
+    CRM_Core_Payment_SDDNG::setPendingContributionID($contribution_id);
 }
 
 /**


### PR DESCRIPTION
The api wrapper for contribution completetransaction does not work (anymore). So we use hook_postSave_civicrm_contribution() instead.
In addition: do not call CRM_Core_Payment_SDDNGPostProcessor::createPendingMandate() for all Forms.