### PR TITLE
Bump min version

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -21,7 +21,7 @@
     <ext version="&gt;=1.5">org.project60.sepa</ext>
   </requires>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.70</ver>
   </compatibility>
   <comments>This used to be part of CiviSEPA and was developed by B. Endres (endres@systopia.de).</comments>
   <civix>


### PR DESCRIPTION
Now that https://github.com/Project60/org.project60.sepapp/pull/48 has been merged, the minimum version is 5.70.