### PR TITLE
Reset event participant to 'Pending from pay later' for SDD payments

### DIFF
--- a/CRM/Core/Payment/SDDNGPostProcessor.php
+++ b/CRM/Core/Payment/SDDNGPostProcessor.php
@@ -116,6 +116,12 @@ class CRM_Core_Payment_SDDNGPostProcessor implements API_Wrapper {
       $ooff_payment = (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'OOFF');
       self::resetContribution($contribution_id, $ooff_payment);
       CRM_Sepapp_Configuration::log("Contribution [{$contribution_id}] adjusted.", CRM_Sepapp_Configuration::LOG_LEVEL_AUDIT);
+
+      // reset any linked event participant(s) to 'Pending from pay later':
+      // for a paid event registration CiviCRM treats the SDD direct debit like a
+      // completed payment and sets the participant to 'Registered', but the money
+      // has not been collected yet (see resetParticipants).
+      self::resetParticipants($contribution_id);
     }
     else {
       // RECURRING DONATION
@@ -187,6 +193,69 @@ class CRM_Core_Payment_SDDNGPostProcessor implements API_Wrapper {
                      AND etx.entity_table = 'civicrm_contribution');", [
                        1 => [$contribution_id, 'Integer'],
                      ]);
+  }
+
+  /**
+   * Reset any event participant(s) linked to this contribution to
+   * 'Pending from pay later'.
+   *
+   * When registering for a paid event, the SDD direct debit payment processor is
+   * treated by CiviCRM core like a completed payment, so the participant is
+   * created with status 'Registered'. The SDD mandate has only been created
+   * though - the money has not been collected yet - so the participant should be
+   * 'Pending from pay later', matching the (already reset) pending contribution.
+   *
+   * Only participants currently in 'Registered' are touched, so we don't override
+   * cancelled/waitlisted/etc. statuses.
+   *
+   * @param $contribution_id int Contribution ID
+   */
+  public static function resetParticipants($contribution_id) {
+    $pending_status_id = (int) CRM_Core_DAO::singleValueQuery(
+      "SELECT id FROM civicrm_participant_status_type WHERE name = 'Pending from pay later'"
+    );
+    $registered_status_id = (int) CRM_Core_DAO::singleValueQuery(
+      "SELECT id FROM civicrm_participant_status_type WHERE name = 'Registered'"
+    );
+    if (!$pending_status_id || !$registered_status_id) {
+      CRM_Sepapp_Configuration::log("Couldn't resolve participant status types, not resetting participant.", CRM_Sepapp_Configuration::LOG_LEVEL_ERROR);
+      return;
+    }
+
+    // find participant(s) linked to this contribution
+    $participant_payments = civicrm_api3('ParticipantPayment', 'get', [
+      'contribution_id' => $contribution_id,
+      'option.limit' => 0,
+    ]);
+    foreach ($participant_payments['values'] as $participant_payment) {
+      $participant_id = (int) $participant_payment['participant_id'];
+
+      // only downgrade 'Registered' participants
+      $current_status_id = (int) CRM_Core_DAO::singleValueQuery(
+        "SELECT status_id FROM civicrm_participant WHERE id = %1",
+        [1 => [$participant_id, 'Integer']]
+      );
+      if ($current_status_id !== $registered_status_id) {
+        continue;
+      }
+
+      try {
+        civicrm_api3('Participant', 'create', [
+          'id' => $participant_id,
+          'status_id' => $pending_status_id,
+        ]);
+      }
+      catch (Exception $ex) {
+        // don't leave it as 'Registered' - fall back to SQL
+        $error_message = $ex->getMessage();
+        CRM_Sepapp_Configuration::log("SDD reset participant via API failed ('{$error_message}'), using SQL...", CRM_Sepapp_Configuration::LOG_LEVEL_INFO);
+        CRM_Core_DAO::executeQuery("UPDATE civicrm_participant SET status_id = %1 WHERE id = %2;", [
+          1 => [$pending_status_id, 'Integer'],
+          2 => [$participant_id, 'Integer'],
+        ]);
+      }
+      CRM_Sepapp_Configuration::log("Participant [{$participant_id}] reset to 'Pending from pay later'.", CRM_Sepapp_Configuration::LOG_LEVEL_AUDIT);
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Sepapp/BasicTest.php
+++ b/tests/phpunit/CRM/Sepapp/BasicTest.php
@@ -146,6 +146,61 @@ class CRM_Sepapp_BasicTest extends \PHPUnit\Framework\TestCase implements Headle
     $this->assertEquals('TEST '. $test_id, $sepaMandates['source']);
   }
 
+  /**
+   * A paid event registration paid via SDD must leave the participant in
+   * 'Pending from pay later', not 'Registered', since the money has not been
+   * collected yet.
+   */
+  public function testEventParticipantResetNG(): void {
+    $test_id = 'event-' . mt_rand();
+    $contribution = $this->createTestContribution($test_id);
+
+    $registered_status_id = \Civi\Api4\ParticipantStatusType::get(FALSE)
+      ->addWhere('name', '=', 'Registered')
+      ->execute()->first()['id'];
+    $pending_status_id = \Civi\Api4\ParticipantStatusType::get(FALSE)
+      ->addWhere('name', '=', 'Pending from pay later')
+      ->execute()->first()['id'];
+
+    // create an event with a participant 'Registered' linked to the contribution
+    $event = \Civi\Api4\Event::create(FALSE)->setValues([
+      'title' => 'SEPA Test Event',
+      'event_type_id' => 1,
+      'start_date' => '2025-04-01',
+      'is_active' => TRUE,
+      'is_monetary' => TRUE,
+    ])->execute()->first();
+
+    $participant = \Civi\Api4\Participant::create(FALSE)->setValues([
+      'contact_id' => 1,
+      'event_id' => $event['id'],
+      'status_id' => $registered_status_id,
+    ])->execute()->first();
+
+    \Civi\Api4\ParticipantPayment::create(FALSE)->setValues([
+      'participant_id' => $participant['id'],
+      'contribution_id' => $contribution['id'],
+    ])->execute();
+
+    // set test data and run the post processor (creates mandate + resets)
+    CRM_Core_Payment_SDDNG::setPendingMandateData([
+      'payment_processor_id' => 1,
+      'iban' => self::TEST_IBAN,
+      'bic' => "BEVODEBB",
+    ]);
+    CRM_Core_Payment_SDDNGPostProcessor::createPendingMandate();
+
+    // the participant should now be 'Pending from pay later'
+    $updated = \Civi\Api4\Participant::get(FALSE)
+      ->addWhere('id', '=', $participant['id'])
+      ->execute()->first();
+    $this->assertEquals(
+      $pending_status_id,
+      $updated['status_id'],
+      "Participant should be reset to 'Pending from pay later'"
+    );
+  }
+
   public function createTestContribution(string $name): array {
     return \Civi\API4\Contribution::create(FALSE)->setValues(
       [


### PR DESCRIPTION
## Problem

When registering for a **paid event** via the `Payment_SDDNG` direct debit payment processor, the SEPA mandate and a *pending* contribution are created correctly, but the event participant is left in status **Registered** instead of **Pending from pay later**.

### Why

`SDDNG` is a *direct* payment processor, so CiviCRM core treats the registration like a completed payment: it creates the contribution as *Completed* and the participant as *Registered*. The extension's post-processor (`SDDNGPostProcessor::createPendingMandate()`) then resets the **contribution** back to *Pending* via `resetContribution()` — but nothing ever resets the **participant**, which stays at *Registered* even though no money has been collected yet (the mandate still has to be submitted to the bank).

## Fix

Add `resetParticipants()`, called from the OOFF branch of `createPendingMandate()` right after `resetContribution()`. It finds the participant(s) linked to the contribution via `civicrm_participant_payment` and, **only if currently in `Registered`**, downgrades them to `Pending from pay later`. Cancelled/waitlisted/etc. statuses are left untouched. Mirrors the existing `resetContribution()` style (API first, SQL fallback).

## Test

Adds `testEventParticipantResetNG`, which creates a contribution, an event and a `Registered` participant linked via `ParticipantPayment`, runs `createPendingMandate()`, and asserts the participant ends up `Pending from pay later`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)