### PR TITLE
fix substr cutting special character

### DIFF
--- a/CRM/Core/Payment/SDDNGPostProcessor.php
+++ b/CRM/Core/Payment/SDDNGPostProcessor.php
@@ -108,7 +108,7 @@ class CRM_Core_Payment_SDDNGPostProcessor implements API_Wrapper {
         'date' => date('YmdHis'),
         'creation_date' => date('YmdHis'),
         'validation_date' => date('YmdHis'),
-        'source' => substr($contribution['contribution_source'], 0, 64),
+        'source' => mb_substr($contribution['contribution_source'], 0, 64),
       ]);
       CRM_Sepapp_Configuration::log("OOFF mandate [{$mandate['id']}] created.", CRM_Sepapp_Configuration::LOG_LEVEL_AUDIT);
 
@@ -135,7 +135,7 @@ class CRM_Core_Payment_SDDNGPostProcessor implements API_Wrapper {
         'date' => date('YmdHis'),
         'creation_date' => date('YmdHis'),
         'validation_date' => date('YmdHis'),
-        'source' => substr($contribution['contribution_source'], 0, 64),
+        'source' => mb_substr($contribution['contribution_source'], 0, 64),
       ]);
       CRM_Sepapp_Configuration::log("RCUR mandate [{$mandate['id']}] created.", CRM_Sepapp_Configuration::LOG_LEVEL_AUDIT);
 


### PR DESCRIPTION
substr cuts special character in half. So one should replace this function with mb_substring.

Example: A event has the name and the event title contains ß so that it becomes the 64 th character of the contribution source. Then it gets cut in https://github.com/Project60/org.project60.sepapp/blob/a676114d1c919a08fa2f3e95460da20ab75df1e2/CRM/Core/Payment/SDDNGPostProcessor.php#L111

and the mechanism breaks. This PR replaces all occurences of `substr`.