### PR TITLE
remove hiding payment instrument id on admin page

### DIFF
--- a/templates/CRM/Admin/Form/PaymentProcessor/SDD.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor/SDD.tpl
@@ -63,7 +63,6 @@
     cj('#test_url_site').parent().parent().remove();
     cj('#test_url_recur').parent().parent().remove();
     cj('.crm-paymentProcessor-form-block-accept_credit_cards').hide();
-    cj('tr.crm-paymentProcessor-form-block-payment-instrument-id').hide();
 
     // adjust help text
     cj('.crm-paymentProcessor-form-block-user_name').find('.helpicon').replaceWith(cj('#creditor_id_help'));


### PR DESCRIPTION
The admin page of a sepa Payment Processor is hiding the payment_instrument_id for some reasons, from years ago. When creating a new Payment Processor, the payment_instrument_id is falsly set to the default (for us PayPal, which we also use). 

As the payment Processor rewrites the contributions it does not come up in civicrm, BUT in the confirmation emails sent. There the payment_instrument_id:label is falsly PayPal. Because the payment_instrument_id is taken from the paymentProcessor entry in cicivcrm_payment_processor.payment_instrument_id. 

This PR makes it possible to fix the Problem in the Admin Frontend.